### PR TITLE
Remove backticks from blog inline code and tweak styles

### DIFF
--- a/src/blog.css
+++ b/src/blog.css
@@ -2,19 +2,20 @@
   background: white;
 }
 
-.prose :where(code):not(:where([class~="not-prose"] *)) {
-  color: var(--astro-code-color-text);
+.prose :where(code):not(:where([class~='not-prose'] *)) {
+  color: var(--astro-code-token-string);
   background-color: var(--astro-code-color-background);
   padding-top: 0.3em;
   padding-right: 0.3em;
   padding-bottom: 0.2em;
   padding-left: 0.3em;
+  border-radius: 0.2rem;
 }
 
-.prose :where(code):not(:where([class~="not-prose"] *))::before {
-  content: "";
+.prose :where(code):not(:where([class~='not-prose'] *))::before {
+  content: '';
 }
 
-.prose :where(code):not(:where([class~="not-prose"] *))::after {
-  content: "";
+.prose :where(code):not(:where([class~='not-prose'] *))::after {
+  content: '';
 }


### PR DESCRIPTION
Styles colour and background for inline code blocks on the blog so that they are more similar to bigger code blocks.

This commit also removes the backticks that appear around inline code, since this looks a bit like markdown syntax that is failing to parse.