### PR TITLE
Remove padding from first line of multi-line code blocks

### DIFF
--- a/src/blog.css
+++ b/src/blog.css
@@ -12,6 +12,10 @@
   border-radius: 0.2rem;
 }
 
+pre.astro-code code {
+  padding: 0;
+}
+
 .prose :where(code):not(:where([class~='not-prose'] *))::before {
   content: '';
 }


### PR DESCRIPTION
Minor fix to multi-line code blocks on the blog, where the first line was picking up styling intended for inline code, putting it out of alignment with the rest of the code.