### PR TITLE
Add initial FeatureSection for team profiles

### DIFF
--- a/src/components/team/ContactSection.astro
+++ b/src/components/team/ContactSection.astro
@@ -1,5 +1,4 @@
 ---
-import { getImage, Image } from 'astro:assets'
 import Section from '@components/team/Section.astro'
 import ContactItem from '@components/team/ContactItem.astro'
 import ContactUsProfile from '@components/ContactUsProfile'

--- a/src/components/team/DisplayImage.astro
+++ b/src/components/team/DisplayImage.astro
@@ -1,0 +1,18 @@
+---
+import AssetImage from '@components/team/AssetImage.astro'
+
+const { link } = Astro.props;
+---
+<div class="relative group">
+  {
+    link &&
+    <a class="hidden group-hover:grid absolute bg-white/25 w-full h-full place-items-center"
+       href={link}
+       target="_blank">
+      <span class="bg-juxt px-4 py-3 text-white hover:text-zinc-800 rounded-sm">
+        Find out more
+      </span>
+    </a>
+  }
+  <AssetImage className="hover:greyscale" {...Astro.props} />
+</div>

--- a/src/components/team/FeatureSection.astro
+++ b/src/components/team/FeatureSection.astro
@@ -1,0 +1,16 @@
+---
+import Section from '@components/team/Section.astro'
+
+const {imgPos = "left"} = Astro.props;
+---
+<Section pClass="" className="grid grid-cols-1 md:grid-cols-2" {...Astro.props}>
+    {
+      (imgPos == "left") && <slot name="image"/>
+    }
+    <div class="p-10">
+        <slot/>
+    </div>
+    {
+      (imgPos == "right") && <slot name="image"/>
+    }
+</Section>

--- a/src/components/team/Section.astro
+++ b/src/components/team/Section.astro
@@ -1,8 +1,8 @@
 ---
-var {bgClass, bgStyle, bgColor, className} = Astro.props;
+var {bgClass = "", bgStyle = "", bgColor = "grey", className = ""} = Astro.props;
 
 // NOTE: Also change in LatestBlogsSection
-// TODO: Move somewhere else?
+// TODO: Move somewhere else? Tailwind?
 if (bgColor == "orange") {
     bgClass += " bg-[#b76330]";
 } else if (bgColor == "yellow") {

--- a/src/components/team/Section.astro
+++ b/src/components/team/Section.astro
@@ -1,5 +1,5 @@
 ---
-var {bgClass = "", bgStyle = "", bgColor = "grey", className = ""} = Astro.props;
+var {bgClass = "", bgStyle = "", bgColor = "grey", pClass = "px-10", className = ""} = Astro.props;
 
 // NOTE: Also change in LatestBlogsSection
 // TODO: Move somewhere else? Tailwind?
@@ -21,7 +21,7 @@ if (bgColor == "orange") {
 }
 {
     !(bgClass || bgStyle) &&
-    <div class={"container mx-auto lg:max-w-5xl px-10 " + className}>
+    <div class={"container mx-auto lg:max-w-5xl " + pClass + " " + className}>
         <slot/>
     </div>
 }

--- a/src/pages/team/xxx.astro
+++ b/src/pages/team/xxx.astro
@@ -31,6 +31,7 @@ import LatestBlogsSection from '@components/team/LatestBlogsSection.astro'
 import ResourceCollectionSection from '@components/team/ResourceCollectionSection.astro'
 import ResourceItem from '@components/team/ResourceItem.astro'
 import ContactSection from '@components/team/ContactSection.astro'
+import FeatureSection from '@components/team/FeatureSection.astro'
 import GallerySection from '@components/team/GallerySection.astro'
 import GalleryImage from '@components/team/GalleryImage.astro'
 import SmallTitle from '@components/team/SmallTitle.astro'
@@ -49,6 +50,16 @@ import SimpleColumn from '@components/team/SimpleColumn.astro'
       <li>Platform Engineering</li>
     </ul>
   </GreetingSection>
+
+  <FeatureSection link="/jdt-tech-roundtable">
+    <AssetImage slot="image" src="/src/assets/blog/confs.jpg" alt="" />
+    <SimpleColumn>
+      <SmallTitle>Technology Roundtable</SmallTitle>
+      <p>
+        Something here about the roundtable and why it's good.
+      </p>
+    </SimpleColumn>
+  </FeatureSection>
 
   <GallerySection>
     <GalleryImage
@@ -71,6 +82,16 @@ import SimpleColumn from '@components/team/SimpleColumn.astro'
         src="/src/assets/blog/confs.jpg"
         alt="People talking around a convention desk" />
   </GallerySection>
+
+  <FeatureSection link="/jdt-tech-roundtable" imgPos="right">
+    <AssetImage slot="image" src="/src/assets/blog/confs.jpg" alt="" />
+    <SimpleColumn>
+      <SmallTitle>Technology Roundtable</SmallTitle>
+      <p>
+        Something here about the roundtable and why it's good.
+      </p>
+    </SimpleColumn>
+  </FeatureSection>
 
   <TwoColumnSection>
     <SimpleColumn>

--- a/src/pages/team/xxx.astro
+++ b/src/pages/team/xxx.astro
@@ -32,6 +32,7 @@ import ResourceCollectionSection from '@components/team/ResourceCollectionSectio
 import ResourceItem from '@components/team/ResourceItem.astro'
 import ContactSection from '@components/team/ContactSection.astro'
 import FeatureSection from '@components/team/FeatureSection.astro'
+import DisplayImage from '@components/team/DisplayImage.astro'
 import GallerySection from '@components/team/GallerySection.astro'
 import GalleryImage from '@components/team/GalleryImage.astro'
 import SmallTitle from '@components/team/SmallTitle.astro'
@@ -51,8 +52,8 @@ import SimpleColumn from '@components/team/SimpleColumn.astro'
     </ul>
   </GreetingSection>
 
-  <FeatureSection link="/jdt-tech-roundtable">
-    <AssetImage slot="image" src="/src/assets/blog/confs.jpg" alt="" />
+  <FeatureSection>
+    <DisplayImage slot="image" link="/jdt-tech-roundtable" src="/src/assets/blog/confs.jpg" alt="" />
     <SimpleColumn>
       <SmallTitle>Technology Roundtable</SmallTitle>
       <p>
@@ -83,8 +84,8 @@ import SimpleColumn from '@components/team/SimpleColumn.astro'
         alt="People talking around a convention desk" />
   </GallerySection>
 
-  <FeatureSection link="/jdt-tech-roundtable" imgPos="right">
-    <AssetImage slot="image" src="/src/assets/blog/confs.jpg" alt="" />
+  <FeatureSection imgPos="right">
+    <DisplayImage slot="image" link="/jdt-tech-roundtable" src="/src/assets/blog/confs.jpg" alt="" />
     <SimpleColumn>
       <SmallTitle>Technology Roundtable</SmallTitle>
       <p>


### PR DESCRIPTION
Adds:
- Initial `FeatureSection` for an image + text pair, allowing the image to be on the left or right
- `DisplayImage` which shows a cover with a button when hovered over

Problems:
- The image:
  - Doesn't go to the edge of the screen on widescreens
  - On mobile is too big
- The styling of the cover is meh
- The interface
  - Maybe: have props: `title`, `imgPos`, `imgSrc`, `imgAlt`?
    - Including `title` because it should be clickable really