### PR TITLE
Scale back dark mode to just blogs

### DIFF
--- a/src/algolia.css
+++ b/src/algolia.css
@@ -1,11 +1,4 @@
-:root,
-:root.light {
-  --inputBackground: #fff;
-  --inputBorderColor: #d1d5db;
-  --inputColor: #1f2937;
-  --inputCaretColor: #1f2937;
-}
-:root.dark {
+:root {
   --inputBackground: #1f2937;
   --inputBorderColor: #374151;
   --inputColor: #e5e7eb;
@@ -47,31 +40,30 @@
   background-color: var(--inputBackground);
 }
 
-.dark .ais-Pagination-link {
+.ais-Pagination-link {
   background: var(--inputBackground);
   color: var(--inputColor);
   border-color: #6b7280;
 }
 
-.dark .ais-Pagination-item--disabled .ais-Pagination-link {
+.ais-Pagination-item--disabled .ais-Pagination-link {
   background: #374151;
   border-color: #6b7280;
 }
 
-.dark .ais-Pagination-item--selected .ais-Pagination-link {
+.ais-Pagination-item--selected .ais-Pagination-link {
   background: #374151;
   border-color: #6b7280;
   box-shadow: rgb(0 0 0 / 66%) 0 1px 7px 0 inset,
     rgb(0 0 0 / 40%) 0 1px 1px 0 inset, rgb(0 0 0 / 5%) 0 1px 0 0;
 }
 
-.dark .ais-Pagination-link:active {
+.ais-Pagination-link:active {
   box-shadow: rgb(0 0 0 / 66%) 0 1px 7px 0 inset,
     rgb(0 0 0 / 40%) 0 1px 1px 0 inset, rgb(0 0 0 / 5%) 0 1px 0 0;
 }
 
-.dark
-  .ais-Pagination-item:not(.ais-Pagination-item--selected):not(.ais-Pagination-item--disabled)
+.ais-Pagination-item:not(.ais-Pagination-item--selected):not(.ais-Pagination-item--disabled)
   .ais-Pagination-link:hover {
   background: #374151;
   border-color: #6b7280;

--- a/src/components/DarkModeSwitch.tsx
+++ b/src/components/DarkModeSwitch.tsx
@@ -1,6 +1,18 @@
 import { useState, useEffect } from 'preact/hooks'
 
-export default function DarkModeSwitch() {
+// Here's how dark mode works for this site:
+// - Tailwind is configured to use a class for dark mode: https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
+// - In src/layouts/Layout.astro
+//  - If localStorage.theme is set we use that
+//  - Otherwise If the browser set `(prefers-color-scheme: <whatever>)` we use that
+//  - Otherwise we default to "light"
+// - In src/components/DarkModeSwitch.tsx
+//  - Toggle between themes
+//  - Set localStorage.theme to the current theme
+//
+// TODO: Have some way to reset localStorage.theme?
+
+export default function DarkModeSwitch(props) {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     if (import.meta.env.SSR) {
       return undefined
@@ -27,24 +39,22 @@ export default function DarkModeSwitch() {
   }
 
   return (
-    <div class='w-6 h-6' onClick={toggleTheme}>
+    <div class={'w-6 h-6 ' + (props.class ? props.class : "")} onClick={toggleTheme}>
       <button
         class='flex items-center justify-center h-full w-full bg-none border-none text-inherit cursor-pointer p-0'
         type='button'
-        title='Switch between dark and light mode'
+        title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
         aria-label='Switch between dark and light mode'
       >
-        {theme === 'light' ? (
+        {theme === 'dark' ? (
           <svg viewBox='0 0 24 24' width='24' height='24'>
             <path
-              fill='white'
               d='M12,9c1.65,0,3,1.35,3,3s-1.35,3-3,3s-3-1.35-3-3S10.35,9,12,9 M12,7c-2.76,0-5,2.24-5,5s2.24,5,5,5s5-2.24,5-5 S14.76,7,12,7L12,7z M2,13l2,0c0.55,0,1-0.45,1-1s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S1.45,13,2,13z M20,13l2,0c0.55,0,1-0.45,1-1 s-0.45-1-1-1l-2,0c-0.55,0-1,0.45-1,1S19.45,13,20,13z M11,2v2c0,0.55,0.45,1,1,1s1-0.45,1-1V2c0-0.55-0.45-1-1-1S11,1.45,11,2z M11,20v2c0,0.55,0.45,1,1,1s1-0.45,1-1v-2c0-0.55-0.45-1-1-1C11.45,19,11,19.45,11,20z M5.99,4.58c-0.39-0.39-1.03-0.39-1.41,0 c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0s0.39-1.03,0-1.41L5.99,4.58z M18.36,16.95 c-0.39-0.39-1.03-0.39-1.41,0c-0.39,0.39-0.39,1.03,0,1.41l1.06,1.06c0.39,0.39,1.03,0.39,1.41,0c0.39-0.39,0.39-1.03,0-1.41 L18.36,16.95z M19.42,5.99c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06c-0.39,0.39-0.39,1.03,0,1.41 s1.03,0.39,1.41,0L19.42,5.99z M7.05,18.36c0.39-0.39,0.39-1.03,0-1.41c-0.39-0.39-1.03-0.39-1.41,0l-1.06,1.06 c-0.39,0.39-0.39,1.03,0,1.41s1.03,0.39,1.41,0L7.05,18.36z'
             ></path>
           </svg>
-        ) : theme === 'dark' ? (
+        ) : theme === 'light' ? (
           <svg viewBox='0 0 24 24' width='24' height='24'>
             <path
-              fill='white'
               d='M9.37,5.51C9.19,6.15,9.1,6.82,9.1,7.5c0,4.08,3.32,7.4,7.4,7.4c0.68,0,1.35-0.09,1.99-0.27C17.45,17.19,14.93,19,12,19 c-3.86,0-7-3.14-7-7C5,9.07,6.81,6.55,9.37,5.51z M12,3c-4.97,0-9,4.03-9,9s4.03,9,9,9s9-4.03,9-9c0-0.46-0.04-0.92-0.1-1.36 c-0.98,1.37-2.58,2.26-4.4,2.26c-2.98,0-5.4-2.42-5.4-5.4c0-1.81,0.89-3.42,2.26-4.4C12.92,3.04,12.46,3,12,3L12,3z'
             ></path>
           </svg>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -30,15 +30,10 @@ const pagesInNavbar = navbar.map((page) => ({
   style: page.style,
   active: page.href === currentPage
 }))
-
-const firstPathInUrl = Astro.url.pathname.split('/')[1]
-const enableDarkMode =
-  firstPathInUrl === 'blog' || firstPathInUrl === 'clojure-in'
 ---
 
 <Navbar
   client:visible
   navLinks={pagesInNavbar}
-  enableDarkMode={enableDarkMode}
   navbarNoBg={navbarNoBg}
 />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,6 @@ import 'preact/jsx-runtime'
 import classNames from 'classnames'
 import { useEffect, useState } from 'preact/hooks'
 import { useOutsideClick } from '@utils/preactUtils'
-import DarkModeSwitch from './DarkModeSwitch'
 
 type NavLinkProp = {
   href: string
@@ -35,7 +34,7 @@ function NavLink({ label, href, target, active, style }: NavLinkProp) {
   )
 }
 
-export default function Navbar({ navLinks, enableDarkMode, navbarNoBg }) {
+export default function Navbar({ navLinks, navbarNoBg }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const ref = useOutsideClick(() => setIsMenuOpen(false))
   const linkClasses = 'items-center gap-8 uppercase tracking-widest text-xs'
@@ -101,7 +100,6 @@ export default function Navbar({ navLinks, enableDarkMode, navbarNoBg }) {
               style={page.style}
             />
           ))}
-          {enableDarkMode && <DarkModeSwitch />}
         </div>
 
         {/* mobile */}
@@ -127,7 +125,6 @@ export default function Navbar({ navLinks, enableDarkMode, navbarNoBg }) {
               style={page.style}
             />
           ))}
-          {enableDarkMode && <DarkModeSwitch />}
         </div>
       </div>
     </nav>

--- a/src/components/Newsletter.astro
+++ b/src/components/Newsletter.astro
@@ -5,7 +5,7 @@ import Section from './Section.astro'
 <Section className='py-20 text-white bg-black'>
   <div>
     <header class='py-16 sm:text-center'>
-      <h1 class='mb-4 text-4xl font-bold tracking-tight dark:text-slate-200'>
+      <h1 class='mb-4 text-4xl font-bold tracking-tight'>
         Stay in touch
       </h1>
       <p class='lg:w-1/2 mx-auto text-lg text-slate-400'>

--- a/src/components/team/LatestBlogsSection.astro
+++ b/src/components/team/LatestBlogsSection.astro
@@ -50,7 +50,8 @@ const blogs = filteredBlogs
     </div>
   </Section>
 
-  <div class={"grid grid-cols-1 lg:grid-cols-[repeat(2,_24rem)] xl:grid-cols-[repeat(3,_24rem)] gap-10 justify-center" + bgClass}>
+  { /* This component is styled in dark mode only, so we set dark mode for the blog cards */ }
+  <div class={"dark grid grid-cols-1 lg:grid-cols-[repeat(2,_24rem)] xl:grid-cols-[repeat(3,_24rem)] gap-10 justify-center " + bgClass}>
     {
       blogs[0] &&
       <div class="">

--- a/src/layouts/BlogIndex.tsx
+++ b/src/layouts/BlogIndex.tsx
@@ -27,7 +27,8 @@ function CustomHits({ blogs }) {
     return blogs.get(hit.permalink)
   })
   return (
-    <div>
+    /* This component is styled in dark mode only, so we set dark mode for the blog cards */
+    <div class="dark">
       <div className='grid md:grid-cols-[repeat(2,_24rem)] xl:grid-cols-[repeat(3,_24rem)] justify-center gap-10'>
         {filteredHits.map((hit) => (
           <div key={hit.permalink}>
@@ -53,7 +54,7 @@ export function BlogIndex({ blogs }: { blogs: Map<string, Blog> }) {
           <SearchBox />
           <div className='flex justify-between'>
             <button
-              className='text-xs bg-slate-200 dark:bg-slate-600 dark:text-white dark:hover:text-slate-600 dark:hover:bg-slate-200 text-slate-800 hover:bg-slate-400 transition-all hover:text-white rounded-md px-2 py-1'
+              className='text-xs bg-slate-600 text-white hover:text-slate-600 hover:bg-slate-200 transition-all rounded-md px-2 py-1'
               onClick={() => setFiltersVisible(!filtersVisible)}
             >
               Show Filters
@@ -61,7 +62,7 @@ export function BlogIndex({ blogs }: { blogs: Map<string, Blog> }) {
           </div>
 
           <div
-            className={`transition-all text-black dark:text-white flex flex-wrap justify-between pt-4 overflow-hidden
+            className={`transition-all text-white flex flex-wrap justify-between pt-4 overflow-hidden
               ${filtersVisible ? 'h-full opacity-100' : 'h-0 opacity-0'}`}
           >
             <div className='flex flex-col gap-2'>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -140,7 +140,7 @@ const categoryHref = `/blog?${encodeURI(
   ogImage={heroImageFilename}
 >
   <DraftBanner draft={draft} pageName='Blog' />
-  <main class='transition-colors'>
+  <main class='transition-colors dark:bg-gray-900'>
     <div class='px-4 sm:px-12 2xl:px-0 max-w-7xl mx-auto'>
       <div class='flex flex-col lg:flex-row gap-12 items-center pt-10'>
         <div

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -14,6 +14,7 @@ import { Blog, Person } from '@utils/types'
 import { parseBlogs } from '@utils/common'
 import Layout from './Layout.astro'
 import { getImage } from 'astro:assets'
+import DarkModeSwitch from '../components/DarkModeSwitch'
 
 const { title, description, heroImage, category, author, draft } = Astro.props
   .content as Blog
@@ -216,6 +217,7 @@ const categoryHref = `/blog?${encodeURI(
       <div
         class='pb-20 pt-6 flex justify-center items-center gap-4 lg:justify-end'
       >
+        <DarkModeSwitch client:only class={shareIconStyle} />
         <div class='flex justify-around text-sm items-center'>
           <a
             class='w-6 h-6'

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,13 +39,6 @@ const [{ seo }] = await Astro.glob<Metadata>('../data/metadata.json')
 const currentDescription =
   ogDescription ?? (seo[currentPageName] && seo[currentPageName].description)
 
-const enableDarkMode =
-  Astro.url.pathname.includes('/blog') ||
-  Astro.url.pathname.includes('/clojure-in') ||
-  Astro.url.pathname.includes('/privacy-policy') ||
-  Astro.url.pathname.includes('/terms-of-use') ||
-  Astro.url.pathname.includes('/tnc2023')
-
 // image attributes must be all jpgs and located in src/assets/site/ dir
 let imageForShare
 if (seo[currentPageName] && seo[currentPageName].image) {
@@ -123,17 +116,13 @@ const metaTitle = ogTitle ?? currentPageName
     <title>{title || capitalizeFirstLetter(currentPageName)}</title>
     <!-- This is intentionally inlined to avoid FOUC -->
     <script>
-      const root = document.documentElement
-      const theme = localStorage.getItem('theme')
-      if (
-        theme === 'dark' ||
-        (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)
-      ) {
-        root.classList.add('dark')
-        document.documentElement.style.setProperty('color-scheme', 'dark')
+      // See src/components/DarkModeSwitch.tsx for more info on dark mode setup
+
+      // Source: https://tailwindcss.com/docs/dark-mode#supporting-system-preference-and-manual-selection
+      if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark')
       } else {
-        document.documentElement.style.setProperty('color-scheme', 'light')
-        root.classList.remove('dark')
+        document.documentElement.classList.remove('dark')
       }
     </script>
     <style>
@@ -142,6 +131,9 @@ const metaTitle = ogTitle ?? currentPageName
       }
     </style>
     <script>
+      // Add a "Add to clipboard" button to all code blocks
+      // TODO: maybe this could be a rehype/remark plugin?
+
       let blocks = document.querySelectorAll("pre");
 
       blocks.forEach((block) => {
@@ -184,12 +176,8 @@ const metaTitle = ogTitle ?? currentPageName
       data-website-id='4a088aa2-1e6f-4f97-9e95-9619983468de'
       src='https://bunseki.juxt.pro/t.js'></script>
   </head>
-  <body
-    class:list={[
-      'bg-gray-50 transition-colors',
-      { 'dark:bg-gray-900': enableDarkMode }
-    ]}
-  >
+  <body 
+      class='bg-gray-50 transition-colors'>
     {navbar && <Navbar navbarNoBg={navbarNoBg} />}
     <div class:list={[{ 'pt-14': !navbarNoBg && navbar }]}>
       <slot />

--- a/src/layouts/PolicyTerms.astro
+++ b/src/layouts/PolicyTerms.astro
@@ -8,7 +8,7 @@ const { title } = Astro.props.content as TermsPolicyProps
 
 <Layout navbar title={title}>
   <main
-    class='py-12 mx-auto prose prose-a:text-juxt hover:prose-a:text-black prose-a:transition-colors dark:prose-invert dark:hover:prose-a:text-white'
+    class='py-12 mx-auto prose prose-a:text-juxt hover:prose-a:text-black prose-a:transition-colors'
   >
     <Section>
       <slot />

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -46,9 +46,11 @@ const blogBannerPicture = await getImage({
 ---
 
 <Layout navbar title='Blog'>
-  <Banner
-    text='Blog'
-    style={{ backgroundImage: `url(${blogBannerPicture})` }}
-  />
-  <BlogIndex client:only='preact' blogs={blogsByHref} />
+  <div class="bg-gray-900">
+    <Banner
+      text='Blog'
+      style={{ backgroundImage: `url(${blogBannerPicture})` }}
+    />
+    <BlogIndex client:only='preact' blogs={blogsByHref} />
+  </div>
 </Layout>

--- a/src/pages/qr.astro
+++ b/src/pages/qr.astro
@@ -73,7 +73,7 @@ const boxStructure = [
             return (
               <a
                 href={box.href}
-                class='group h-full group cursor-pointer flex flex-col w-96 mx-auto bg-gradient-to-b from-white to-neutral-100 dark:from-slate-700 dark:to-slate-800 min-h-[24rem] overflow-hidden relative shadow-lg hover:shadow-2xl transition-all'
+                class='group h-full group cursor-pointer flex flex-col w-96 mx-auto bg-gradient-to-b from-white to-neutral-100 min-h-[24rem] overflow-hidden relative shadow-lg hover:shadow-2xl transition-all'
               >
                 <div class='p-4 text-2xl group-hover:text-juxt transition-colors'>
                   {box.title}


### PR DESCRIPTION
- Simplify the dark mode setup
  - Remove `enableDarkMode` and similar, this way it works uniformly across the site
  - Use the tailwind example for picking the darkmode class
  - Only use the `DarkModeSwitch` component for setting dark mode dynamically
- Style the whole website with just the dark theme styles
- Remove the switch from most pages
- Add the switch to the blog page under the image