### PR TITLE
Hotfix for canonical url

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -25,11 +25,11 @@ export default defineConfig({
     })
   ],
   site:
-    (process.env.NODE_ENV === 'development' ||
+    process.env.NODE_ENV === 'development' ||
     process.env.CONTEXT === 'deploy-preview' ||
     process.env.CONTEXT === 'branch-deploy'
       ? process.env.DEPLOY_URL || process.env.URL
-      : PRODUCTION_SITE_URL)?.replace(/\/$/, ''),
+      : PRODUCTION_SITE_URL,
   markdown: {
     shikiConfig: {
       theme: 'css-variables'

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -102,9 +102,7 @@ const metaTitle = ogTitle ?? title ?? currentPageName
 
     {Astro.site && <link
       rel='canonical'
-      href={Astro.url.pathname.endsWith('/')
-        ? `${Astro.site}${Astro.url.pathname}`
-        : `${Astro.site}${Astro.url.pathname}/`}
+      href={`${Astro.site.href.replace(/\/$/, '')}${Astro.url.pathname}`}
     />}
 
     <link


### PR DESCRIPTION
Fix canonical URLs to use custom domain in production

Configure Astro site URL to use https://juxt.pro for production deploys while preserving Netlify URLs for preview/branch deploys and localhost for development. Update layout meta tags and image URLs to use Astro.site instead of request URL