### PR TITLE
set site and improve canonical

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,20 +10,24 @@ import rehypeSlug from 'rehype-slug'
 import remarkGfm from 'remark-gfm'
 import remarkMath from 'remark-math'
 
+// netlify - build vars https://docs.netlify.com/build/configure-builds/environment-variables/
 const PRODUCTION_SITE_URL = 'https://juxt.pro'
 
-console.log(
-  '-------------------------------- CONFIG SITE --------------------------------',
-  process.env.DEPLOY_URL || process.env.URL
-)
-console.log(
-  'CONFIG SITE:',
-  process.env.NODE_ENV === 'development' ||
-    process.env.CONTEXT === 'deploy-preview' ||
-    process.env.CONTEXT === 'branch-deploy'
-    ? process.env.DEPLOY_URL || process.env.URL
-    : PRODUCTION_SITE_URL
-)
+function getSiteUrl() {
+  if (process.env.NODE_ENV === 'development') {
+    return 'http://localhost:4321'
+  }
+  if (process.env.CONTEXT === 'deploy-preview') {
+    return process.env.DEPLOY_URL
+  }
+
+  if (process.env.CONTEXT === 'production') {
+    // https://juxt.pro
+    return process.env.URL
+  }
+
+  return PRODUCTION_SITE_URL
+}
 
 // https://astro.build/config
 export default defineConfig({
@@ -37,12 +41,7 @@ export default defineConfig({
       }
     })
   ],
-  site:
-    process.env.NODE_ENV === 'development' ||
-    process.env.CONTEXT === 'deploy-preview' ||
-    process.env.CONTEXT === 'branch-deploy'
-      ? process.env.DEPLOY_URL || process.env.URL
-      : PRODUCTION_SITE_URL,
+  site: getSiteUrl(),
   markdown: {
     shikiConfig: {
       theme: 'css-variables'

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,8 @@ import { capitalizeFirstLetter, currentPage } from '@utils/common'
 
 import { getImage } from 'astro:assets'
 
+const siteOrigin = Astro.site.origin
+
 type LayoutProps = {
   title?: string
   navbar?: boolean
@@ -41,17 +43,6 @@ const {
   noFooter,
   robots
 } = Astro.props as LayoutProps
-
-console.log(
-  '-------------------------------- Environment variables --------------------------------'
-)
-console.log('url -> new URL(Astro.request.url)', url)
-console.log('Astro.site', Astro.site)
-
-console.log('process.env.NODE_ENV', process.env.NODE_ENV)
-console.log('process.env.CONTEXT', process.env.CONTEXT)
-console.log('process.env.DEPLOY_URL', process.env.DEPLOY_URL)
-console.log('process.env.URL', process.env.URL)
 const [{ seo }] = await Astro.glob<Metadata>('../data/metadata.json')
 
 const currentDescription =
@@ -67,13 +58,11 @@ if (seo[currentPageName] && seo[currentPageName].image) {
     alt: 'background',
     quality: 90
   }).then((img) => img.src)
-  imageForShare = Astro.site ? `${Astro.site}${importedPic}` : importedPic
-  console.log('imageForShare old url', `${url.origin}${importedPic}`)
-  console.log('imageForShare new url', `${Astro.site}${importedPic}`)
+  imageForShare = `${siteOrigin}${importedPic}`
 } else if (ogImage) {
   if (ogImage.startsWith('/')) {
     // Direct path, no dynamic import needed
-    imageForShare = Astro.site ? `${Astro.site}${ogImage}` : ogImage
+    imageForShare = `${siteOrigin}${ogImage}`
   } else {
     // would be nice not to hardcode blog here, but then vite can't do the dynamic import...
     // this whole dynamic import thing is nasty anyway, probably its better to
@@ -86,12 +75,9 @@ if (seo[currentPageName] && seo[currentPageName].image) {
       alt: 'blog background',
       height: 630
     })
-    imageForShare = Astro.site ? `${Astro.site}${src}` : src
+    imageForShare = `${siteOrigin}${src}`
   }
 }
-
-console.log('url.href', url.href)
-console.log('Astro.url.pathname', `${Astro.site}${Astro.url.pathname}`)
 
 const metaTitle = ogTitle ?? title ?? currentPageName
 ---
@@ -106,14 +92,9 @@ const metaTitle = ogTitle ?? title ?? currentPageName
       )
     }
     <!-- Meta Tags -->
-    {
-      Astro.site && (
-        <meta
-          property='og:url'
-          content={`${Astro.site}${Astro.url.pathname}`}
-        />
-      )
-    }
+
+    <meta property='og:url' content={Astro.site.href} />
+
     <meta property='og:type' content='website' />
     <meta property='og:title' content={ogTitle} />
     <meta property='og:description' content={ogDescription} />
@@ -124,14 +105,8 @@ const metaTitle = ogTitle ?? title ?? currentPageName
       )
     }
 
-    {
-      Astro.site && (
-        <link
-          rel='canonical'
-          href={`${Astro.site.href.replace(/\/$/, '')}${Astro.url.pathname}`}
-        />
-      )
-    }
+    <!-- we want the canonical URL to always be production, so we use the netlify process.env.URL -->
+    <link rel='canonical' href={`${process.env.URL}${Astro.url.pathname}`} />
 
     <link
       rel='alternate'
@@ -141,23 +116,8 @@ const metaTitle = ogTitle ?? title ?? currentPageName
     />
 
     <!-- Twitter Meta Tags -->
+    <!-- https://developer.x.com/en/docs/x-for-websites/cards/overview/markup -->
     <meta name='twitter:card' content='summary_large_image' />
-    {
-      Astro.site && (
-        <meta
-          property='twitter:domain'
-          content={new URL(Astro.site).hostname}
-        />
-      )
-    }
-    {
-      Astro.site && (
-        <meta
-          property='twitter:url'
-          content={`${Astro.site}${Astro.url.pathname}`}
-        />
-      )
-    }
     <meta name='twitter:title' content={metaTitle} />
     {
       currentDescription && (


### PR DESCRIPTION
In this PR the `site` configuration in `astro.config.ts` is never `null`. It defaults to `localhost:port`, deploy preview url, or prod url based on the environment.

Additionally, the canonical URL should always be `process.env.URL`, which is populated by netlify to always be `https://juxt.pro`. In this way, we'll never get flagged for duplicate content no matter the number of deployed previews.