### PR TITLE
Surface agentic development story on Meridian page

### DIFF
--- a/src/pages/meridian.astro
+++ b/src/pages/meridian.astro
@@ -127,7 +127,7 @@ import Layout from '@layouts/Layout.astro'
 
       <!-- Sub-headline -->
       <p class='meridian-stagger-4 text-lg md:text-xl text-gray-400 font-light max-w-2xl leading-relaxed mb-4'>
-        An equity derivatives post-trade risk management system built from decades of investment banking experience.
+        Decades of banking expertise, amplified by agentic development.<br />Same calibre. New velocity.
       </p>
 
       <!-- Tagline -->
@@ -171,8 +171,10 @@ import Layout from '@layouts/Layout.astro'
             without demanding you rip out what already works.
           </p>
           <p>
-            Meridian was built agentically, encoding our engineering judgement into a system
-            that reflects the patterns we know work at scale in production:
+            Meridian isn't AI-generated software. It's what happens when senior engineers
+            with decades of banking experience adopt a
+            <span class='text-gray-800 font-normal'>disciplined agentic workflow</span>
+            — encoding the patterns we know work at scale in production:
             <span class='text-gray-800 font-normal'>immutable data, deterministic computation, and full reproducibility</span>
             of every risk calculation, every position, every trade lifecycle event.
           </p>
@@ -278,6 +280,71 @@ import Layout from '@layouts/Layout.astro'
     </div>
   </section>
 
+  <!-- How We Build -->
+  <section class='bg-white'>
+    <div class='max-w-7xl mx-auto px-6 md:px-12 lg:px-20 py-24 md:py-32'>
+      <div class='flex flex-col items-center text-center mb-16 md:mb-20'>
+        <p class='text-juxt text-xs font-semibold tracking-[0.2em] uppercase mb-4'>How We Build</p>
+        <h2 class='text-4xl md:text-5xl lg:text-6xl font-extralight text-gray-900'>
+          Agentic Development,<br />Applied to Hard Problems
+        </h2>
+        <p class='text-gray-500 text-lg font-light max-w-2xl mt-6 leading-relaxed'>
+          AI amplifies. JUXT brings the engineering discipline
+          and domain expertise. Agentic development is the multiplier.
+        </p>
+      </div>
+
+      <div class='grid md:grid-cols-3 gap-6 lg:gap-8'>
+        <!-- Rigour at Velocity -->
+        <div class='relative p-8 md:p-10 border border-gray-200 transition-all duration-300 hover:border-juxt/40 hover:-translate-y-0.5'>
+          <div class='flex-shrink-0 w-10 h-10 flex items-center justify-center border border-juxt/30 text-juxt mb-6'>
+            <svg xmlns='http://www.w3.org/2000/svg' class='w-5 h-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.5'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z' />
+            </svg>
+          </div>
+          <h3 class='text-xl font-medium text-gray-900 mb-3'>Rigour at Velocity</h3>
+          <p class='text-gray-500 font-light leading-relaxed'>
+            Senior engineers paired with AI, moving at
+            <span class='text-gray-800 font-normal'>startup speed with investment-bank
+            discipline</span>. Every feature goes through formal design, specification, and review
+            before a line of code is written. The AI doesn't replace engineering judgement — it multiplies it.
+          </p>
+        </div>
+
+        <!-- Domain Expertise, Amplified -->
+        <div class='relative p-8 md:p-10 border border-gray-200 transition-all duration-300 hover:border-juxt/40 hover:-translate-y-0.5'>
+          <div class='flex-shrink-0 w-10 h-10 flex items-center justify-center border border-juxt/30 text-juxt mb-6'>
+            <svg xmlns='http://www.w3.org/2000/svg' class='w-5 h-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.5'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M12 18v-5.25m0 0a6.01 6.01 0 001.5-.189m-1.5.189a6.01 6.01 0 01-1.5-.189m3.75 7.478a12.06 12.06 0 01-4.5 0m3.75 2.383a14.406 14.406 0 01-3 0M14.25 18v-.192c0-.983.658-1.823 1.508-2.316a7.5 7.5 0 10-7.517 0c.85.493 1.509 1.333 1.509 2.316V18' />
+            </svg>
+          </div>
+          <h3 class='text-xl font-medium text-gray-900 mb-3'>Domain Expertise, Amplified</h3>
+          <p class='text-gray-500 font-light leading-relaxed'>
+            Complex derivatives systems demand deep understanding — pricing models,
+            risk calculations, regulatory constraints, CDM standards. JUXT brings decades
+            of experience building these systems at Tier 1 banks. Agentic development means
+            that <span class='text-gray-800 font-normal'>expertise is delivered faster, not diluted</span>.
+          </p>
+        </div>
+
+        <!-- Confidence in the Output -->
+        <div class='relative p-8 md:p-10 border border-gray-200 transition-all duration-300 hover:border-juxt/40 hover:-translate-y-0.5'>
+          <div class='flex-shrink-0 w-10 h-10 flex items-center justify-center border border-juxt/30 text-juxt mb-6'>
+            <svg xmlns='http://www.w3.org/2000/svg' class='w-5 h-5' fill='none' viewBox='0 0 24 24' stroke='currentColor' stroke-width='1.5'>
+              <path stroke-linecap='round' stroke-linejoin='round' d='M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z' />
+            </svg>
+          </div>
+          <h3 class='text-xl font-medium text-gray-900 mb-3'>Confidence in the Output</h3>
+          <p class='text-gray-500 font-light leading-relaxed'>
+            Every feature is formally specified before implementation. The engineering
+            bar — <span class='text-gray-800 font-normal'>exhaustive testing, behavioural specifications, architectural rigour</span> — is
+            higher than most hand-built systems. It just gets there faster.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- Video / Demo Section -->
   <section class='bg-gradient-to-b from-moonlight to-gray-900'>
     <div class='max-w-7xl mx-auto px-6 md:px-12 lg:px-20 py-24 md:py-32'>
@@ -322,6 +389,7 @@ import Layout from '@layouts/Layout.astro'
               handling real volumes in real regulatory environments.
             </p>
             <p>
+              <span class='text-gray-800 font-normal'>The engineer holds the standard. The AI handles the breadth.</span>
               Built agentically, Meridian represents a new approach to accelerator development:
               our senior engineers' experience and judgement,
               amplified by AI, producing a system with the depth and rigour of a multi-year build


### PR DESCRIPTION
Reframe the Meridian page to foreground JUXT's disciplined agentic workflow as a core part of the narrative, not a passing mention.

- Hero sub-headline leads with expertise + agentic development
- "What is Meridian" copy reframed around disciplined agentic workflow
- New "How We Build" section: Rigour at Velocity, Domain Expertise Amplified, Confidence in the Output
- Expertise section led with "The engineer holds the standard. The AI handles the breadth."