### PR TITLE
XT26: forward form submissions to Orbit via Netlify function

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,10 @@
 [context.production]
   command = "yarn build"
 
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
 [[redirects]]
   from = "/sitemap.xml"
   to = "/sitemap-index.xml"

--- a/netlify/functions/xt26-register.ts
+++ b/netlify/functions/xt26-register.ts
@@ -1,0 +1,86 @@
+// Netlify function: forwards XT26 "express interest" form submissions into
+// Orbit (the prospect pipeline at orbit.juxt.pro) as a Prospect row with
+// source="xt26_website_form".
+//
+// Runs alongside the existing web3forms submission path. The form primary-
+// submits to web3forms (email notification + audit trail to demo@juxt.pro);
+// this function is fire-and-forget from the browser, so if it fails the user
+// still sees a successful submission based on the web3forms response.
+//
+// Env:
+//   ORBIT_API_TOKEN  Bearer token in Orbit's api_tokens list. Recommended to
+//                    attribute this to xt26@juxt.pro (dedicated) rather than a
+//                    personal token, so rotation is independent of humans.
+
+type NetlifyEvent = {
+  httpMethod: string
+  body: string | null
+}
+
+type NetlifyResponse = {
+  statusCode: number
+  headers?: Record<string, string>
+  body: string
+}
+
+const ORBIT_URL = 'https://orbit.juxt.pro'
+
+export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => {
+  if (event.httpMethod !== 'POST') {
+    return json(405, { error: 'method not allowed' })
+  }
+
+  const token = process.env.ORBIT_API_TOKEN
+  if (!token) {
+    console.error('xt26-register: ORBIT_API_TOKEN not configured')
+    return json(500, { error: 'token not configured' })
+  }
+
+  let body: Record<string, string>
+  try {
+    body = JSON.parse(event.body ?? '{}')
+  } catch {
+    return json(400, { error: 'invalid json' })
+  }
+
+  const firstName = (body.firstName ?? '').trim()
+  const lastName = (body.lastName ?? '').trim()
+  const email = (body.email ?? '').trim().toLowerCase()
+  if (!firstName || !lastName || !email) {
+    return json(400, { error: 'firstName, lastName, email required' })
+  }
+
+  const payload = {
+    name: `${firstName} ${lastName}`,
+    email,
+    company: (body.company ?? '').trim(),
+    role: (body.jobTitle ?? '').trim(),
+    location: (body.country ?? '').trim(),
+    source: 'xt26_website_form',
+  }
+
+  const r = await fetch(`${ORBIT_URL}/api/people?upsert=true`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  if (!r.ok) {
+    const detail = await r.text().catch(() => '<no body>')
+    console.error('xt26-register: orbit post failed', r.status, detail)
+    return json(502, { error: 'upstream failed' })
+  }
+
+  return json(200, { ok: true })
+}
+
+function json(statusCode: number, body: Record<string, unknown>): NetlifyResponse {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }
+}

--- a/src/components/ContactUsForm.tsx
+++ b/src/components/ContactUsForm.tsx
@@ -37,6 +37,20 @@ export function ContactUsForm(props: ContactUsFormProps) {
   function submitContactForm(data: Record<string, unknown>) {
     const json = JSON.stringify(data)
 
+    // Secondary path (XT26 only): forward into Orbit via Netlify function.
+    // Fire-and-forget — never affects the user-visible submit result, which
+    // is driven entirely by the primary web3forms response below.
+    if (eventName === 'XT26') {
+      fetch('/.netlify/functions/xt26-register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: json
+      }).catch((err) => {
+        console.warn('orbit sync failed (non-fatal)', err)
+      })
+    }
+
+    // Primary: web3forms (email notification + audit trail).
     return fetch('https://api.web3forms.com/submit', {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
- Adds `netlify/functions/xt26-register.ts` which forwards XT26 "express interest" form submissions into Orbit (`POST /api/people?upsert=true`) with `source="xt26_website_form"`.
- Closes the manual-triage gap. Previously submissions went to web3forms only (emailed `demo@juxt.pro`, required Addie to hand-copy into the Online Requests sheet before anything flowed into Orbit / Tito). Orbit now sees submissions in real time.
- web3forms continues firing as the primary path. The Orbit POST is fire-and-forget client-side, so function failures never affect the user-visible submit UX or the `demo@juxt.pro` email audit trail.

## Scoping
The `eventName === 'XT26'` guard in `ContactUsForm.tsx` means only XT26 submissions hit Orbit. Other ContactUs variants (Mini / Tech / Profile / JUXT / FormXT24 / plain) are unchanged.

## Environment setup
Requires `ORBIT_API_TOKEN` Netlify env var (already configured). The token is attributed to `xt26@juxt.pro` in Orbit's `api_tokens` list; the orbit side has deployed to accept it.

## Orbit-side behaviour (confirmed by orbit-side handoff, 2026-04-24)
- `qualification: "active"` - no triage gate
- auto-applied `website` tag
- `ownerEmail: null` - rows surface in the Unclaimed chip for routing
- Slack celebration muted for this source

## Test plan
- [ ] Merge, wait for Netlify deploy on main to go green
- [ ] Submit XT26 form at `juxt.pro/xt26` with a recognisable test email (e.g. `test+orbit@juxt.pro`)
- [ ] Verify via API: ``curl -s -H "Authorization: Bearer $(cat ~/.config/orbit/api-token)" "https://orbit.juxt.pro/api/people?q=xt26_website_form&state=all" | jq '.count, .people[-1] | {name, source, tags, ownerEmail}'`` — expect count incremented, `source="xt26_website_form"`, `tags=["website"]`, `ownerEmail=null`
- [ ] Browser check: `orbit.juxt.pro/people?tag=website` — test row should appear in the Unclaimed chip
- [ ] Confirm no Slack ping in the team channel
- [ ] Delete the test row

## Rollback
Revert the commit. web3forms + the `demo@juxt.pro` email trail are unaffected; worst case is "Orbit doesn't get the row for the duration of the outage".

🤖 Generated with [Claude Code](https://claude.com/claude-code)