### PR TITLE
xt26: move About section above XT25 highlights

### DIFF
--- a/src/components/XT26Page.astro
+++ b/src/components/XT26Page.astro
@@ -80,58 +80,6 @@ const subject = 'XT26 Request for Invite'
     </div>
   </section>
 
-  <!-- About Section -->
-  <section id='about' class='bg-white overflow-hidden'>
-    <div class='max-w-7xl mx-auto px-6 md:px-12 lg:px-20 py-24 md:py-32'>
-      <div class='grid lg:grid-cols-12 gap-12 lg:gap-16 items-center'>
-        <!-- Image - takes 7 cols on desktop, shows first -->
-        <div class='lg:col-span-7 lg:order-1 order-2 relative'>
-          <div
-            class='absolute -inset-6 bg-gradient-to-br from-juxt/5 to-transparent -z-10'
-          >
-          </div>
-          <img
-            src='/images/XT26/Juxt-2025-267.jpg'
-            alt='XT25 Conference - speaker presenting to packed audience'
-            class='w-full aspect-[4/3] object-cover'
-          />
-        </div>
-        <!-- Text - takes 5 cols on desktop -->
-        <div class='lg:col-span-5 lg:order-2 order-1'>
-          <p
-            class='text-juxt text-xs font-semibold tracking-[0.2em] uppercase mb-4'
-          >
-            About the Conference
-          </p>
-          <h2
-            class='text-4xl md:text-5xl font-extralight text-gray-900 leading-tight mb-8'
-          >
-            An Invite-only Event for Engineering Leaders
-          </h2>
-          <div
-            class='space-y-5 text-gray-500 text-base leading-relaxed font-light'
-          >
-            <p>
-              It's our tenth year running the XT conference (2016-2026), and this year
-              bringing together around 250 senior engineering leaders across
-              banking, hedge funds, and financial services, in London's Tower Hill.
-            </p>
-            <p>
-              This is <span class='text-gray-800 font-normal'>pure thought leadership</span>. Real-world experience shared by peers who are actually doing engineering at scale.
-            </p>
-            <p>
-              The conference has grown organically each year, building a
-              community of practitioners focused on solving hard technical
-              problems in financial services.
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </section>
-
-
-
   <!-- Speakers Section -->
   <section id='speakers' class='bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900'>
     <div class='max-w-7xl mx-auto px-6 md:px-12 lg:px-20 py-24 md:py-32'>
@@ -259,6 +207,56 @@ const subject = 'XT26 Request for Invite'
           successTitle='Thank you for your interest'
           successMessage="We'll reach out if spots become available."
         />
+      </div>
+    </div>
+  </section>
+
+  <!-- About Section -->
+  <section id='about' class='bg-white overflow-hidden'>
+    <div class='max-w-7xl mx-auto px-6 md:px-12 lg:px-20 py-24 md:py-32'>
+      <div class='grid lg:grid-cols-12 gap-12 lg:gap-16 items-center'>
+        <!-- Image - takes 7 cols on desktop, shows first -->
+        <div class='lg:col-span-7 lg:order-1 order-2 relative'>
+          <div
+            class='absolute -inset-6 bg-gradient-to-br from-juxt/5 to-transparent -z-10'
+          >
+          </div>
+          <img
+            src='/images/XT26/Juxt-2025-267.jpg'
+            alt='XT25 Conference - speaker presenting to packed audience'
+            class='w-full aspect-[4/3] object-cover'
+          />
+        </div>
+        <!-- Text - takes 5 cols on desktop -->
+        <div class='lg:col-span-5 lg:order-2 order-1'>
+          <p
+            class='text-juxt text-xs font-semibold tracking-[0.2em] uppercase mb-4'
+          >
+            About the Conference
+          </p>
+          <h2
+            class='text-4xl md:text-5xl font-extralight text-gray-900 leading-tight mb-8'
+          >
+            An Invite-only Event for Engineering Leaders
+          </h2>
+          <div
+            class='space-y-5 text-gray-500 text-base leading-relaxed font-light'
+          >
+            <p>
+              It's our tenth year running the XT conference (2016-2026), and this year
+              bringing together around 250 senior engineering leaders across
+              banking, hedge funds, and financial services, in London's Tower Hill.
+            </p>
+            <p>
+              This is <span class='text-gray-800 font-normal'>pure thought leadership</span>. Real-world experience shared by peers who are actually doing engineering at scale.
+            </p>
+            <p>
+              The conference has grown organically each year, building a
+              community of practitioners focused on solving hard technical
+              problems in financial services.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Moves the "An Invite-only Event for Engineering Leaders" About block down to sit just above the Featured Talks from XT25 section.
- New page flow: Hero → Speakers → Agenda → Apply to Attend → About → XT25 highlights.
- The About section's `id='about'` anchor is preserved so any deep links still resolve.

The rationale: the page now gets visitors into speakers / agenda / CTA faster, and the About copy acts as a natural on-ramp to the XT25 past-event content at the bottom (both lean on XT25 imagery).

## Test plan

- [ ] Run dev server, scroll through `/xt26`, confirm new section order and that the About styling still looks right.
- [ ] Click any nav/anchor link pointing at `#about` to confirm it scrolls to the right place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)