### PR TITLE
xt26: honeypot to block bot form spam into Orbit

### DIFF
--- a/netlify/functions/xt26-register.ts
+++ b/netlify/functions/xt26-register.ts
@@ -43,6 +43,19 @@ export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => 
     return json(400, { error: 'invalid json' })
   }
 
+  // Honeypot. The form renders a hidden, off-screen `website` input
+  // that humans never fill. A non-empty value means the submission is
+  // almost certainly a bot — discard it WITHOUT forwarding to Orbit,
+  // and return 200 so the bot can't tell its submission was dropped
+  // (a 4xx would let it detect the trap and tune around it). This is
+  // the primary gate: bots POST straight to this public function
+  // endpoint, so rejecting here stops the spam at the edge. Orbit's
+  // POST /api/people carries the same check as a backstop.
+  if ((body.website ?? '').trim() !== '') {
+    console.warn('xt26-register: honeypot tripped, dropping submission')
+    return json(200, { ok: true })
+  }
+
   const firstName = (body.firstName ?? '').trim()
   const lastName = (body.lastName ?? '').trim()
   const email = (body.email ?? '').trim().toLowerCase()

--- a/src/components/ContactUsForm.tsx
+++ b/src/components/ContactUsForm.tsx
@@ -126,6 +126,22 @@ export function ContactUsForm(props: ContactUsFormProps) {
         value='c2bf653a-2baa-466d-bbcc-390272663918'
       />
 
+      {/* Honeypot. Off-screen (not display:none — sophisticated bots
+          skip hidden fields) and removed from the tab order, so a
+          human never sees or focuses it and it stays empty. A bot
+          that auto-fills every input trips it; the Netlify function
+          and Orbit both silently discard any submission where it's
+          non-empty. Plausible-but-unused field name so bots target
+          it. See juxt/orbit docs/notes/website-form-spam.md. */}
+      <input
+        type='text'
+        tabIndex={-1}
+        autoComplete='off'
+        aria-hidden='true'
+        {...register('website')}
+        style={{ position: 'absolute', left: '-9999px', width: '1px', height: '1px', opacity: 0 }}
+      />
+
       {/* Row 1: Name fields */}
       <div className='grid grid-cols-1 sm:grid-cols-2 gap-8'>
         <input


### PR DESCRIPTION
## Why

Bots have been POSTing gibberish registrations straight to the public
`/.netlify/functions/xt26-register` endpoint — gibberish names/company,
dot-stuffed throwaway gmail addresses — which the function forwarded
into Orbit as prospect rows (`🎉 …gibberish… signed up via the website!`
pings in #orbit, ~8 junk rows as of 2026-05-21).

The Orbit API token isn't browser-exposed — it lives in this function's
env — so the **function endpoint itself is the gate**, not the token.

## What

Two-layer honeypot:

1. **Form** (`src/components/ContactUsForm.tsx`) — a hidden, off-screen
   `website` input. Off-screen (not `display:none`, which sophisticated
   bots skip) and removed from the tab order, so a human never sees or
   focuses it and it stays empty; a bot that auto-fills every input
   trips it.
2. **Netlify function** (`netlify/functions/xt26-register.ts`) — silently
   drops any submission where `website` is non-empty: returns `200 OK`
   and does **not** forward to Orbit, so the bot can't detect the trap
   (a 4xx would let it tune around it).

Orbit's `POST /api/people` carries the same check as a backstop
(already merged to `juxt/orbit` main, commit `6b69678`).

## Notes

- 29 additive lines, no existing code paths touched.
- Non-breaking: real submissions don't fill `website`, so humans are
  unaffected.
- After merge + Netlify deploy, watch the `🎉 …signed up` Slack pings
  for a day or two to confirm the spam stops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)