### PR TITLE
Careers: Senior / Principal Rust Engineer

### DIFF
--- a/src/pages/careers/rust-engineer.md
+++ b/src/pages/careers/rust-engineer.md
@@ -1,0 +1,66 @@
+---
+layout: '../../layouts/CareerPost.astro'
+location: 'London / Hybrid'
+department: 'Engineering'
+contract: 'Full Time'
+position: 'Senior / Principal Rust Engineer'
+description: 'Join JUXT as a Senior / Principal Rust Engineer, building ultra-low-latency, systems-level software for a global financial leader. Full-time, hybrid role in London.'
+draft: false
+weight: 2
+googleJobs:
+  {
+    location: 'London',
+    position: 'Senior / Principal Rust Engineer',
+    publishedDate: '2026-08-11',
+    validThrough: '2027-02-11T00:00',
+    employmentType: 'FULL_TIME'
+  }
+---
+
+## Job Description
+
+We’re looking for experienced Rust engineers to join us on a demanding systems and performance programme with a global financial leader.
+
+You’ll join a small, exceptional team rewriting core parts of an equities execution platform in Rust, where ultra-low latency is the whole point. These are systems that sit close to the metal and leave no room for error, and this is work for people who enjoy understanding how things behave all the way down, from the type system to the memory layout to the way the kernel schedules their code. The teams are deliberately small, heavily AI-assisted, and hold automated testing as non-negotiable.
+
+Rust is central to this role. You’ll use its ownership model and zero-cost abstractions to build software that is both fast and hard to get wrong, and you’ll help set the standards for how we write, test and operate Rust in production. There’s also scope to shape how we bring AI tooling to bear on systems-level work.
+
+If you enjoy solving hard problems, measuring rather than guessing, and building things you can be proud of, you’ll feel right at home.
+
+## Core skills
+
+* Deep, hot-path Rust is essential: allocation-free code on the critical path, lock-free or wait-free data structures, and careful control of memory layout and cache behaviour
+* A firm understanding of latency distributions and how to minimise tail latency (p99.9 and beyond) is essential, along with proven experience building ultra-low-latency, low-jitter systems
+* Mechanical sympathy: CPU cache hierarchy, NUMA and false sharing, plus core isolation, CPU pinning and huge pages
+* Kernel-bypass networking and busy-polling I/O, for example DPDK or Solarflare Onload
+* Rigorous measurement: latency histograms, tail-latency analysis and an awareness of coordinated omission
+* Strong automated testing discipline, treated as essential: property-based tests, deterministic replay and simulation
+* AI-assisted engineering e.g. Claude Code, etc.
+* Clear communication skills and the ability to articulate design and performance decisions
+
+## Nice to have
+
+* Equities execution or market-structure knowledge (cash equities, prime, OMS, smart order routing or FIX). Strongly preferred
+* Experience with matching engines, market data, or exchange or HFT-grade systems
+* Async Rust and Tokio for control-plane and tooling work, distinct from the hot path
+* Experience contributing to open-source or internal frameworks
+
+## What we offer
+
+* Work on a high-profile, long-term programme with a global financial leader. You'll have a significant impact, and a chance to build systems that you can be proud of.
+* Work in a talented team, learning from exceptional colleagues with a real focus on getting things done.
+* Opportunities for learning and growth, including exposure to the latest AI technologies and practices.
+* Great benefits, including full medical, 10% matched pension and regular premium events.
+
+## WFH?
+These roles are hybrid, a mix of remote work and on-site collaboration. You’ll need to be UK-based and within a commutable distance of London.
+
+## Contract type
+Permanent only.
+
+## Eligibility
+Applicants should have a permanent right to work in the UK.
+
+## Interested?
+
+Email careers@juxt.pro with your CV and a brief introduction. Even if you’re not sure you tick every box, we’d still love to hear from you - we’re always keen to meet passionate, technically curious developers and can keep you in mind for future projects if this one isn’t the right fit.

--- a/src/pages/careers/rust-engineer.md
+++ b/src/pages/careers/rust-engineer.md
@@ -29,10 +29,10 @@ If you enjoy solving hard problems, measuring rather than guessing, and building
 
 ## Core skills
 
-* Deep, hot-path Rust is essential: allocation-free code on the critical path, lock-free or wait-free data structures, and careful control of memory layout and cache behaviour
+* Deep, hot-path Rust is essential: writing allocation-free, contention-aware code on the critical path, with careful control of memory layout and data structures
 * A firm understanding of latency distributions and how to minimise tail latency (p99.9 and beyond) is essential, along with proven experience building ultra-low-latency, low-jitter systems
-* Mechanical sympathy: CPU cache hierarchy, NUMA and false sharing, plus core isolation, CPU pinning and huge pages
-* Kernel-bypass networking and busy-polling I/O, for example DPDK or Solarflare Onload
+* Mechanical sympathy: a real feel for how CPU caches, memory layout and contention shape latency, and the techniques used to control them (CPU affinity, NUMA awareness and the like)
+* Familiarity with the techniques used to squeeze latency out of the network and OS path, such as kernel bypass and busy-polling I/O
 * Rigorous measurement: latency histograms, tail-latency analysis and an awareness of coordinated omission
 * Strong automated testing discipline, treated as essential: property-based tests, deterministic replay and simulation
 * AI-assisted engineering e.g. Claude Code, etc.


### PR DESCRIPTION
Adds a Senior / Principal Rust Engineer role to the careers section.

Based on the Senior / Principal Go Engineer page, with a systems and low-latency slant:
- Rust-specific core skills (ownership, lifetimes, traits; concurrency, memory, profiling; Linux fundamentals)
- Nice-to-haves including C/C++ FFI integration, async/Tokio, messaging/protocol work
- Hybrid: one to two office days per week
- Permanent only

Live (`draft: false`). `googleJobs` dates: published 2026-08-11, valid through 2027-02-11 — adjust if needed.