### PR TITLE
XT26: repurpose recordings form to capture XT27 interest

### DIFF
--- a/netlify/functions/xt26-register.ts
+++ b/netlify/functions/xt26-register.ts
@@ -59,7 +59,11 @@ export const handler = async (event: NetlifyEvent): Promise<NetlifyResponse> => 
   // `video-signup` + drops in the follow-up queue). Whitelisted so the
   // public endpoint can't inject an arbitrary source; anything else
   // (incl. omitted) falls back to the generic website form.
-  const ALLOWED_SOURCES = ['xt26_website_form', 'xt26_recording_request']
+  const ALLOWED_SOURCES = [
+    'xt26_website_form',
+    'xt26_recording_request',
+    'xt27_interest',
+  ]
   const source = ALLOWED_SOURCES.includes(body.orbitSource)
     ? body.orbitSource
     : 'xt26_website_form'

--- a/src/components/XT26Page.astro
+++ b/src/components/XT26Page.astro
@@ -5,7 +5,7 @@ import Layout from '@layouts/Layout.astro'
 import XT26Agenda from '@components/XT26Agenda.astro'
 import speakers from '../data/xt26/speakers.json'
 
-const subject = 'XT26 Talks Recording Request'
+const subject = 'XT27 Interest Registration'
 ---
 
 <Layout
@@ -61,7 +61,7 @@ const subject = 'XT26 Talks Recording Request'
         >
       </div>
       <a
-        href='#attend'
+        href='#agenda'
         class='inline-block border border-white/40 text-white px-10 py-5 text-sm tracking-[0.2em] uppercase hover:bg-white hover:text-black transition-all duration-300'
       >
         Watch the Talks
@@ -190,10 +190,10 @@ const subject = 'XT26 Talks Recording Request'
       <div class='max-w-2xl mx-auto'>
         <div class='flex flex-col items-center text-center mb-16'>
           <h2 class='text-4xl md:text-5xl font-extralight text-white mb-6'>
-            XT26 Talks – On-Demand
+            Register Your Interest in XT27
           </h2>
           <p class='text-gray-400 text-lg font-light max-w-md'>
-            We're currently editing all the talks. Fill in the form below, and we'll send you a link to the recordings as soon as they're ready.
+            XT27 will be invite-only and free for senior engineering leaders in banking and fintech. Leave your details and we'll be in touch when registration opens.
           </p>
         </div>
 
@@ -201,13 +201,13 @@ const subject = 'XT26 Talks Recording Request'
           client:only
           subject={subject}
           eventName='XT26'
-          orbitSource='xt26_recording_request'
+          orbitSource='xt27_interest'
           variant='dark'
           transparentInputs
           submitLabelColor='#0b0e14'
-          submitLabel='Send me the link'
+          submitLabel='Register interest'
           successTitle="You're on the list"
-          successMessage="We'll email you when the recordings are ready."
+          successMessage="We'll be in touch when XT27 registration opens."
         />
       </div>
     </div>


### PR DESCRIPTION
## What this does

The XT26 talks are now on YouTube, linked directly from the agenda. So the recordings form on the XT26 page no longer has a job to do. This repurposes it to capture interest in **XT27** instead.

Changes:

- **Form copy** (`XT26Page.astro`): "XT26 Talks – On-Demand" becomes "Register Your Interest in XT27", with matching subject, button and success text.
- **Hero button**: "Watch the Talks" now scrolls to the agenda (where the talks are), not to the form.
- **Orbit source**: the form now sends `orbitSource=xt27_interest`, added to the `ALLOWED_SOURCES` whitelist in `xt26-register.ts`.

The form's structure, styling and dual submit path (web3forms + Orbit) are unchanged. `eventName` stays `XT26` so the Orbit forward still fires.

## How we're tagging these people

Today, `orbitSource=xt26_recording_request` makes Orbit tag the lead `video-signup` and drop it in the follow-up queue. That mapping lives inside Orbit, not here. This repo only sends the source string.

So we're sending a **new** source, `xt27_interest`, that Orbit hasn't seen before.

## What we need a reviewer to confirm

We don't want to assume a new source string just works. Please confirm:

1. Does Orbit accept a source it doesn't recognise, or must the value be pre-registered on the Orbit side first?
2. What should `xt27_interest` map to (tag, queue, follow-up flag)? Does that need setting up in Orbit before this ships?

If Orbit needs a change first, we'll hold this until that's in place.
